### PR TITLE
Fix AuthManager exceptions

### DIFF
--- a/src/jwtauth/__init__.py
+++ b/src/jwtauth/__init__.py
@@ -1,4 +1,4 @@
-from rest_framework import authentication
+from rest_framework import authentication, exceptions
 
 
 class JwtAuthentication(authentication.BaseAuthentication):
@@ -7,6 +7,10 @@ class JwtAuthentication(authentication.BaseAuthentication):
 
         if request.jwtauth.is_authenticated:
             return request.jwtauth.user, None
+
+        if request.jwtauth.access_token or request.jwtauth.refresh_token:
+            # the user attempted to log in but using invalid or expired tokens
+            raise exceptions.AuthenticationFailed("Tokens are either invalid or expired.")
 
         return None
 

--- a/src/jwtauth/admin.py
+++ b/src/jwtauth/admin.py
@@ -1,5 +1,6 @@
 from django.contrib import admin
-from jwtauth.models import BlacklistedToken, ActiveToken
+
+from jwtauth.models import ActiveToken, BlacklistedToken
 
 admin.site.register(BlacklistedToken)
 admin.site.register(ActiveToken)

--- a/src/jwtauth/manager.py
+++ b/src/jwtauth/manager.py
@@ -1,5 +1,4 @@
 from django.conf import settings
-from rest_framework import exceptions
 
 from jwtauth.settings import api_settings
 from jwtauth.tokens import AccessToken, RefreshToken

--- a/src/jwtauth/manager.py
+++ b/src/jwtauth/manager.py
@@ -1,9 +1,8 @@
-from rest_framework import exceptions
 from django.conf import settings
+from rest_framework import exceptions
 
-from jwtauth.tokens import AccessToken, RefreshToken
 from jwtauth.settings import api_settings
-
+from jwtauth.tokens import AccessToken, RefreshToken
 
 ACCESS_TOKEN_KEY = api_settings.ACCESS_TOKEN_COOKIE_NAME
 REFRESH_TOKEN_KEY = api_settings.REFRESH_TOKEN_COOKIE_NAME
@@ -29,12 +28,12 @@ class AuthManager:
             # we end up here if:
             # - one of the tokens was forged by a malicious user
             # - the refresh token was blacklisted
-            raise exceptions.AuthenticationFailed("Invalid tokens")
+            return
 
         if self.access_token.expired():
             if self.refresh_token.expired():
                 # both tokens are expired, the user has to log in again
-                raise exceptions.AuthenticationFailed("Expired tokens")
+                return
 
             # we silently refresh the authentication token and let the user in
             self.silent_refresh = True

--- a/src/jwtauth/models.py
+++ b/src/jwtauth/models.py
@@ -1,5 +1,5 @@
-from django.db import models
 from django.contrib.auth import get_user_model
+from django.db import models
 
 
 class BlacklistedToken(models.Model):

--- a/src/jwtauth/tokens.py
+++ b/src/jwtauth/tokens.py
@@ -1,14 +1,12 @@
 from calendar import timegm
-
-from django.contrib.auth import get_user_model
-
-from datetime import datetime, timezone, timedelta
-
-from jwtauth.utils import generate_unique_token
-from jwtauth.settings import api_settings
-from jwtauth.models import BlacklistedToken, ActiveToken
+from datetime import datetime, timedelta, timezone
 
 import jwt
+from django.contrib.auth import get_user_model
+
+from jwtauth.models import ActiveToken, BlacklistedToken
+from jwtauth.settings import api_settings
+from jwtauth.utils import generate_unique_token
 
 IAT = "iat"
 EXP = "exp"
@@ -165,23 +163,27 @@ class UserToken(Token):
 
 class AccessToken(UserToken):
 
-    def __init__(self, from_encoding=None, from_user=None):
+    def __init__(
+        self, from_encoding=None, from_user=None, duration=api_settings.ACCESS_TOKEN_LIFETIME
+    ):
         super().__init__(
             from_encoding=from_encoding,
             from_data=from_user,
-            duration=api_settings.ACCESS_TOKEN_LIFETIME,
+            duration=duration,
         )
 
 
 class RefreshToken(UserToken):
     TOKEN_STRING_KEY = "token_string"
 
-    def __init__(self, from_encoding=None, from_user=None):
+    def __init__(
+        self, from_encoding=None, from_user=None, duration=api_settings.REFRESH_TOKEN_LIFETIME
+    ):
         self.token_string = None
         super().__init__(
             from_encoding=from_encoding,
             from_data=from_user,
-            duration=api_settings.REFRESH_TOKEN_LIFETIME,
+            duration=duration,
         )
 
     def encode(self, user, data=None) -> None:

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -1,9 +1,13 @@
+from datetime import timedelta
+
 import pytest
-from django.urls import reverse
 from django.test import Client
+from django.urls import reverse
 from rest_framework import status
 
 from jwtauth.models import ActiveToken, BlacklistedToken
+from jwtauth.settings import api_settings
+from jwtauth.tokens import AccessToken, RefreshToken
 
 
 def login(username, password):
@@ -34,6 +38,39 @@ def test_login(user_a, user_a_password):
 
     assert response.status_code == status.HTTP_204_NO_CONTENT
     assert len(response.cookies) == 2
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("view", ["logged1", "logged2"])
+def test_forged_tokens(client, view):
+    client.cookies[api_settings.ACCESS_TOKEN_COOKIE_NAME] = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ1c2VyX2lkIjoxNDEsImlhdCI6MTcxNzMzNjc2OCwiZXhwIjoxN"
+        "zE3MzM3MDY4fQ.Gl5K5xxGIwtYgklWy-3-jGHbOk_bjdCZmtzJbPJsmw8"
+    )
+    client.cookies[api_settings.REFRESH_TOKEN_COOKIE_NAME] = (
+        "eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJ0b2tlbl9zdHJpbmciOiJhQ3gwVlJUU083STBzTU1EWDRITnY2V"
+        "DY5emR5TVYiLCJ1c2VyX2lkIjoxLCJpYXQiOjE3MTczMzY5MzYsImV4cCI6MTcxNzQyMzMzNn0.btM01q-P6UDHAkq"
+        "hZvbkNsyrScDvwLSDKKezD7IJeFU"
+    )
+    response = client.get(reverse(view))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
+
+
+@pytest.mark.django_db
+@pytest.mark.parametrize("view", ["logged1", "logged2"])
+def test_expired_tokens(client, user_a, view):
+    # create valid but expired tokens for user_a
+    access_token = AccessToken(from_user=user_a, duration=timedelta(0))  # zero seconds
+    refresh_token = RefreshToken(from_user=user_a, duration=timedelta(0))  # zero seconds
+    refresh_token.save()
+
+    # set the cookies
+    client.cookies[api_settings.ACCESS_TOKEN_COOKIE_NAME] = access_token.encoding
+    client.cookies[api_settings.REFRESH_TOKEN_COOKIE_NAME] = refresh_token.encoding
+
+    # verify the request to a logged view is forbidden
+    response = client.get(reverse(view))
+    assert response.status_code == status.HTTP_403_FORBIDDEN
 
 
 @pytest.mark.django_db

--- a/tests/test_auth.py
+++ b/tests/test_auth.py
@@ -74,14 +74,9 @@ def test_expired_tokens(client, user_a, view):
 
 
 @pytest.mark.django_db
-def test_protected_view_1(logged_client):
-    response = logged_client.get(reverse("logged1"))
-    assert response.status_code == status.HTTP_204_NO_CONTENT
-
-
-@pytest.mark.django_db
-def test_protected_view_2(logged_client):
-    response = logged_client.get(reverse("logged2"))
+@pytest.mark.parametrize("view", ["logged1", "logged2"])
+def test_protected_view(logged_client, view):
+    response = logged_client.get(reverse(view))
     assert response.status_code == status.HTTP_204_NO_CONTENT
 
 

--- a/tests/test_tokens.py
+++ b/tests/test_tokens.py
@@ -1,9 +1,11 @@
-from jwtauth.tokens import Token, UserToken, AccessToken, RefreshToken
-from datetime import timedelta, datetime, timezone
-from jwtauth.settings import api_settings
-from jwtauth.models import ActiveToken
-import pytest
+from datetime import datetime, timedelta, timezone
+
 import jwt
+import pytest
+
+from jwtauth.models import ActiveToken
+from jwtauth.settings import api_settings
+from jwtauth.tokens import AccessToken, RefreshToken, Token, UserToken
 
 
 def test_valid_token():

--- a/tests/test_views/views.py
+++ b/tests/test_views/views.py
@@ -1,11 +1,10 @@
 from django.contrib.auth import authenticate
-from rest_framework.parsers import JSONParser
-
-from rest_framework.views import APIView
 from rest_framework.decorators import api_view, permission_classes
 from rest_framework.exceptions import AuthenticationFailed
+from rest_framework.parsers import JSONParser
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 
 from jwtauth import login, logout
 


### PR DESCRIPTION
Exceptions upon failed authentication are now raised by `JwtAuthentication.authenticate`. Additional tests were created.